### PR TITLE
Add deleteDatabase method

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,15 @@ manager.prototype = {
     return this.makeRequest("PUT", this.databaseUrl + this.databaseName, null, null);
   },
 
+  /**
+   * Delete the database
+   *
+   * @returns {*|promise}
+   */
+  deleteDatabase: function() {
+    return this.makeRequest("DELETE", this.databaseUrl + this.databaseName, null, null);
+  },
+
   /*
    * Create a new design document with views
    *


### PR DESCRIPTION
Sorry to submit a pull request + version bump for a small change. It's basically because I'm using the deleteDatabase method for this tutorial http://blog.couchbase.com/2016/january/introducing-the-react-native-couchbase-lite-module and I thought it was in the module. I think that in the future the code in index.js could be a separate module that would be used for ReactJS web apps and it would be a peerDependency of react-native-couchbase-lite.
