### PR TITLE
Create podspec

### DIFF
--- a/ReactNativeCouchbaseLite.podspec
+++ b/ReactNativeCouchbaseLite.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/fraserxu/react-native-couchbase-lite.git' }
   s.source_files = 'ios/**/*.{h,m}'
   s.dependency 'couchbase-lite-ios'
+  s.dependency 'couchbase-lite-ios/Listener'
 end

--- a/ReactNativeCouchbaseLite.podspec
+++ b/ReactNativeCouchbaseLite.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/fraserxu/react-native-couchbase-lite.git"
   s.source       = { :git => 'https://github.com/fraserxu/react-native-couchbase-lite.git' }
   s.source_files = 'ios/**/*.{h,m}'
+  s.dependency 'couchbase-lite-ios'
 end

--- a/ReactNativeCouchbaseLite.podspec
+++ b/ReactNativeCouchbaseLite.podspec
@@ -1,0 +1,21 @@
+#
+# Be sure to run `pod lib lint ReactNativeCouchbaseLite' to ensure this is a
+# valid spec and remove all comments before submitting the spec.
+#
+# Any lines starting with a # are optional, but encouraged
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = "ReactNativeCouchbaseLite"
+  s.version          = "0.2.2"
+  s.summary          = "couchbase lite binding for react-native"
+  s.license          = 'MIT'
+  s.platform     = :ios, '7.0'
+  s.requires_arc = true
+  s.authors      = "Fraser Xu <xvfeng123@gmail.com>"
+  s.homepage     = "https://github.com/fraserxu/react-native-couchbase-lite.git"
+  s.source       = { :git => 'https://github.com/fraserxu/react-native-couchbase-lite.git' }
+  s.source_files = 'ios/**/*.{h,m}'
+end


### PR DESCRIPTION
Adding a Podspec so it can be added to a Podfile for React Native projects that use CocoaPods.
This will automatically pull the `couchbase-lite-ios` dependency.

Also I advise to start tagging versions:

```
  s.source       = { :git => 'https://github.com/fraserxu/react-native-couchbase-lite.git' }
```

should really be 

```
  s.source       = { :git => 'https://github.com/fraserxu/react-native-couchbase-lite.git', :tag => 'v0.2.2' }
```

once a tag has been created. 

In order to use it this way, add the following to Podfile e.g.

```
pod 'ReactNativeCouchbaseLite', :path => './node_modules/react-native-couchbase-lite'
```

Then `pod install`

I had to do the following to get it the project to compile, in addition to `pod install`:

Drag CBLRegisterJSViewCompiler.h into the couchbase-lite-ios Pod
![screen shot 2016-01-21 at 11 01 42](https://cloud.githubusercontent.com/assets/14980/12478728/812aa506-c02e-11e5-995a-74280a3eead0.png)

Add CBLRegisterJSViewCompiler static library
![screen shot 2016-01-21 at 11 34 06](https://cloud.githubusercontent.com/assets/14980/12479543/943c1b20-c033-11e5-8847-ceb6fb11cf96.png)

Add CBLRegisterJSViewCompiler location to `Library Search Paths`
![screen shot 2016-01-21 at 11 41 52](https://cloud.githubusercontent.com/assets/14980/12479602/0e0da14e-c034-11e5-9179-c0aed3cb5b07.png)
