### PR TITLE
Update Podfile refs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ $ npm install react-native-couchbase-lite
 * In the `Podfile`, add dependencies:
 
 ```
-pod 'React', :path => './node_modules/react-native'
-pod 'ReactNativeCouchbaseLite', :path => './node_modules/react-native-couchbase-lite'
+pod 'React', :path => '../node_modules/react-native'
+pod 'ReactNativeCouchbaseLite', :path => '../node_modules/react-native-couchbase-lite'
 ```
 
 * Install the Cocoapods dependencies:


### PR DESCRIPTION
Typically AFAIK React Native projects have the iOS part under an ios subdirectory, but the node_modules are in the project root so the Podfile references should be up one level.
