### PR TITLE
Fix longpolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,15 +364,18 @@ this.database.getAllDocumentConflicts()
 Register for changes:
 
 ```
-db.listen();
+db.getInfo()
+  .then((res) => {
+    db.listen({since: res.update_seq - 1, feed: 'longpoll'});
+  });
 ```
 
 Receiving change notifications:
 
 ```
 db.changesEventEmitter.on('changes', function (e) {
-	console.log(e);
-});
+  console.log(e);
+}.bind(this));
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -216,12 +216,12 @@ this.database.getDocument(documentId)
   });
 ```
 
-### updateDocument(jsonDocument, documentRevision)
+### updateDocument(jsonDocument, documentId, documentRevision)
 Example: Update a _person_ document, change the _gender_ field
 ```
 personDocument.gender = 'male';
 
-this.database.updateDocument(document, documentRevision)
+this.database.updateDocument(personDocument, documentId, documentRevision)
   then((res) => {
     console.log("Updated document", res);
   });

--- a/ReactNativeCouchbaseLiteExample/index.android.js
+++ b/ReactNativeCouchbaseLiteExample/index.android.js
@@ -55,7 +55,7 @@ var Home = React.createClass({
         database.replicate('http://localhost:4984/moviesapp', 'myapp');
         database.getInfo()
           .then((res) => {
-            database.listen({seq: res.update_seq - 1, feed: 'longpoll'});
+            database.listen({since: res.update_seq - 1, feed: 'longpoll'});
             database.changesEventEmitter.on('changes', function (e) {
               this.setState({sequence: e.last_seq});
             }.bind(this));

--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ manager.prototype = {
       request.onload = (e) => {
         var data = JSON.parse(request.responseText);
         self.changesEventEmitter.emit(CHANGE_EVENT_TYPE, data);
-        params.seq = data.last_seq;
+        params.since = data.last_seq;
         poller(databaseUrl, databaseName, params);
       };
       request.open('GET', databaseUrl + databaseName + '/_changes' + this._getFullUrl(params));

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ manager.prototype = {
    *
    * @param object jsonDocument
    * @param string documentId
-   * @param string documentRevision (optional)
+   * @param string documentRevision (required if updating an existing document)
    * @returns {*|promise}
    */
   updateDocument: function (jsonDocument, documentId, documentRevision) {


### PR DESCRIPTION
Longpoll on `listen()` not working correctly because we are sending an invalid sequence filter. 

This caused the xmlhttprequest to be called rapid fire in a loop without waiting for changes.
https://github.com/couchbaselabs/react-native-couchbase-lite/issues/32#issuecomment-215681037

This pull request changes the sequence filter param name from `seq` to `since`
http://developer.couchbase.com/documentation/mobile/1.2/develop/references/couchbase-lite/rest-api/database/get-changes/index.html#story-h2-2
