### PR TITLE
updateDocument to accept _id and _rev as part of jsonDocument

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,7 @@ manager.prototype = {
 
   /**
    * Creates a new document or creates a new revision of an existing document
+   * documentId and documentRevision may be omitted if present in jsonDocument
    *
    * @param object jsonDocument
    * @param string documentId
@@ -184,10 +185,19 @@ manager.prototype = {
 
     if (documentRevision) {
       options.rev = documentRevision;
+    } else if (jsonDocument.hasOwnProperty('_rev')) {
+      options.rev = jsonDocument._rev;
+      jsonDocument._rev = undefined;
+    }
+
+    if (!documentId && jsonDocument.hasOwnProperty('_id')) {
+      documentId = jsonDocument._id;
+      jsonDocument._id = undefined;
     }
 
     return this.makeRequest("PUT", this.databaseUrl + this.databaseName + "/" + documentId, options, jsonDocument);
   },
+
 
   /**
    * Delete a particular document based on its id and revision


### PR DESCRIPTION
Allow `updateDocument` to accept `_rev` and `_id` as part of the object as well as separate arguments. I.e. so there is the option of calling `updateDocument(doc)` without separate id and revision as long as they are present in the `doc` object. This makes sense as usually the documents are held in application memory with their corresponding `_rev` and `_id` properties, therefore simplifying the API. 
