### PR TITLE
Fixed react-native version 0.40 header file breaking change

### DIFF
--- a/ios/ReactCBLite.h
+++ b/ios/ReactCBLite.h
@@ -6,7 +6,12 @@
 //  Copyright © 2015 Couchbase. All rights reserved.
 //
 
-#import <RCTBridgeModule.h>
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
+#endif
+
 #import <CouchbaseLiteListener/CBLListener.h>
 
 @interface ReactCBLite : NSObject <RCTBridgeModule>


### PR DESCRIPTION
Starting with RN 0.40 there is a breaking change with how header files are imported. Looked at other projects, this pattern of checking seems to be the most compatible fix. https://github.com/facebook/react-native/wiki/Breaking-Changes#namespace-all-header-imports-to-react-e1577d---javache 